### PR TITLE
Fix Carrier mod conflicts

### DIFF
--- a/config/carrier.json
+++ b/config/carrier.json
@@ -1,0 +1,4 @@
+{
+  "type": "BLACKLIST",
+  "list": ["sandwichable:sandwich_table"]
+}

--- a/config/carrier.json
+++ b/config/carrier.json
@@ -1,4 +1,7 @@
 {
   "type": "BLACKLIST",
-  "list": ["sandwichable:sandwich_table"]
+  "list": [
+    "sandwichable:sandwich_table",
+    "packages:package"
+  ]
 }


### PR DESCRIPTION
Currently you cannot pick up finished sandwiches from the sandwich table (#136), or insert a stack of items into a package from the Packages mod (#138) with sneak + right click because that picks up the targeted block with Carrier. 

This PR adds the sandwich table and packages to the Carrier block blacklist.

Tested and working in the latest pack version.