### PR TITLE
Tweak BLAST gunpowder block recipe to not conflict with charm

### DIFF
--- a/kubejs/server_scripts/conflicts.js
+++ b/kubejs/server_scripts/conflicts.js
@@ -4,6 +4,15 @@
 
 events.listen("recipes", function (event) {
 
+  //Gunpowder Block
+  event.remove({ output: "blast:gunpowder_block" });
+
+  event.shaped(item.of("blast:gunpowder_block"), [
+    ["minecraft:gunpowder", "minecraft:gunpowder", "minecraft:gunpowder"],
+    ["minecraft:gunpowder", "minecraft:coal_block", "minecraft:gunpowder"],
+    ["minecraft:gunpowder", "minecraft:gunpowder", "minecraft:gunpowder"],
+  ]);
+
   // Kitchen Knife
   event.remove({ output: "sandwichable:kitchen_knife" });
 


### PR DESCRIPTION
This was mentioned in the discord by me. I think this recipe is a decent compromise and will allow us to keep the functionality of both blocks.